### PR TITLE
added ability to query alternative lang post/page by id 

### DIFF
--- a/includes/query.php
+++ b/includes/query.php
@@ -28,6 +28,26 @@ function bogo_parse_query( $query ) {
 		}
 	}
 
+
+
+	/*
+	when search is using post_id, we'll pull the slug and use that instead
+	for searching.
+	*/
+	if (!empty($qv['post__in'])) {
+		$post_slugs = array();
+
+		foreach ($qv['post__in'] as $key => $post_id) {
+			$post = get_post($post_id);
+			if ($post) {
+				$post_slugs[] = $post->post_name;
+				unset($qv['post__in'][$key]);
+			}
+		}
+
+		$qv['post_name__in'] = $post_slugs;
+	}
+
 	$lang = isset( $qv['lang'] ) ? $qv['lang'] : '';
 
 	if ( is_admin() ) {


### PR DESCRIPTION
Wanted to have options to pull in alternative language through REST-API using ID.

This allows endpoints like the following to get the following endpoints:
**For Pages:**
`/wp-json/wp/v2/pages?include[]=37&lang=zh`

**For Posts:**
`/wp-json/wp/v2/posts?include[]=1&lang=zh`